### PR TITLE
Alert组件：fix组件容器元素无子节点报错的bug

### DIFF
--- a/src/Alert.js
+++ b/src/Alert.js
@@ -388,7 +388,12 @@ define(
             }
 
             // 插入节点，引起渲染
-            this.insertBefore(lib.g(this.container).firstChild);
+            if (lib.g(this.container).firstChild) {
+                this.insertBefore(lib.g(this.container).firstChild);
+            }
+            else {
+                this.appendTo(lib.g(this.container));
+            }
 
             // toggle效果实现
             this.helper.addPartClasses('toggle', 'container');


### PR DESCRIPTION
之前采用insertBefore(container.firstChild)
在container当前无任何子节点时会报错，比如container写成<div id="container"></div>