### PR TITLE
修复ToggleSelector getRawValue的bug

### DIFF
--- a/src/selectors/ToggleSelector.js
+++ b/src/selectors/ToggleSelector.js
@@ -133,8 +133,8 @@ define(
         exports.getRawValue = function () {
             var target = this.viewContext.getSafely(this.targetControl);
             var rawValue = target.getRawValue();
-            if (rawValue.length > 0) {
-                return rawValue[0][this.valueField];
+            if (rawValue) {
+                return rawValue[this.valueField];
             }
         };
 


### PR DESCRIPTION
`TableRichSelector`单选模式下`getRawValue`方法返回值不是数组