### PR TITLE
设置richselector中的searchbox为instant模式，防止搜索关键词置空时出现的交互困惑

### DIFF
--- a/src/selectors/RichSelector.js
+++ b/src/selectors/RichSelector.js
@@ -172,7 +172,7 @@ define(
                         ' class="' + this.helper.getPartClassName('search-wrapper') + '">',
                         '   <div',
                         '   data-ui="buttonPosition:right;buttonVariants:bordered icon;',
-                        '   type:SearchBox;childName:itemSearch;variants:clear-border hide-searched-button">',
+                        '   type:SearchBox;childName:itemSearch;variants:clear-border hide-searched-button;searchMode:instant;" >',
                         '   </div>',
                         '</div>'
                     ].join('');


### PR DESCRIPTION
设置richselector中的searchbox为instant模式，防止搜索关键词置空时出现的交互困惑